### PR TITLE
remove db dependency from initializers

### DIFF
--- a/config/initializers/register_mocks.rb
+++ b/config/initializers/register_mocks.rb
@@ -1,3 +1,12 @@
 require 'duckrails/router'
 
-Duckrails::Router.register_current_mocks if ActiveRecord::Base.connection.table_exists? Duckrails::Mock.table_name
+begin
+  # Don't register mocks if there are pending migrations
+  Duckrails::Router.register_current_mocks if ActiveRecord::Base.connection.table_exists? Duckrails::Mock.table_name
+
+rescue ActiveRecord::NoDatabaseError => e
+rescue Mysql2::Error => e
+  Rails.logger.info "Skipping mock route registration, no database."
+  Rails.logger.debug e.message
+  Rails.logger.debug e.backtrace
+end


### PR DESCRIPTION
This was causing an issue while building a docker image when
the database isn't available. Specifically rake assets:precompile
was failing.