### PR TITLE
Fix nodejs version regression in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.4-stretch
 LABEL maintainer="Lazarus Lazaridis http://iridakos.com"
 
 # Change to repo directory


### PR DESCRIPTION
Switch to ruby:2.4-stretch to ensure nodejs 4.8.2 is installed.

iridakos/duckrails:release-v2.1.3 nodejs --version => v4.8.2
iridakos/duckrails:release-v2.1.4 nodejs --version => v0.10.29