### PR TITLE
Simplify route reloader and ensure threadsafe

### DIFF
--- a/app/models/duckrails/application_state.rb
+++ b/app/models/duckrails/application_state.rb
@@ -13,17 +13,14 @@ module Duckrails
     def update_token(type)
       case type
       when :mock
-        self.mock_synchronization_token = Synchronizer.generate_token
+        after_save :save_timestamp
         save
       end
     end
 
-    class << self
-      # @return [ApplicationState] the one and only application state
-      def instance
-        ApplicationState.first || ApplicationState.create(singleton_guard: 0,
-                                                          mock_synchronization_token: Synchronizer.generate_token)
-      end
+    def save_timestamp
+      ts = Time.zone.now.to_i
+      Rails.cache.write(:routes_changed_timestamp, ts)
     end
   end
 end

--- a/lib/duckrails/router.rb
+++ b/lib/duckrails/router.rb
@@ -7,7 +7,6 @@ module Duckrails
     class << self
       def register_mock(mock)
         REGISTERED_MOCKS << mock.id
-        Duckrails::ApplicationState.instance.update_token :mock
         REGISTERED_MOCKS.uniq!
       end
 
@@ -19,7 +18,6 @@ module Duckrails
 
       def unregister_mock(mock)
         REGISTERED_MOCKS.delete mock.id
-        Duckrails::ApplicationState.instance.update_token :mock
       end
 
       def reset!

--- a/lib/duckrails/synchronizer.rb
+++ b/lib/duckrails/synchronizer.rb
@@ -1,18 +1,15 @@
 module Duckrails
   class Synchronizer
-    cattr_accessor :mock_synchronization_token
-
     def initialize(app)
       @app = app
     end
 
     def call(env)
-      application_state = Duckrails::ApplicationState.instance
-
-      if Duckrails::Synchronizer.mock_synchronization_token != application_state.mock_synchronization_token
+      timestamp = Rails.cache.read(:routes_changed_timestamp)
+      if Thread.current[:routes_changed_timestamp] != timestamp
         Rails.logger.info 'Mock synchronization token missmatch. Syncronizing...'
         Router.reset!
-        Duckrails::Synchronizer.mock_synchronization_token = application_state.mock_synchronization_token
+        Thread.current[:routes_changed_timestamp] = timestamp
         Rails.logger.info 'Mock synchronization completed.'
       end
 


### PR DESCRIPTION
Heavily inspired by: https://stackoverflow.com/questions/48506247/rails-reload-dynamic-routes-on-multiple-instances-servers

Avoid using Application State and use Rails.cache for Route reload state.

Fix: https://github.com/iridakos/duckrails/issues/30